### PR TITLE
Documentation for SST faulty behavior

### DIFF
--- a/DataStreaming/ADIOS_ondemand/README.md
+++ b/DataStreaming/ADIOS_ondemand/README.md
@@ -45,8 +45,23 @@ Step 3 is not read by any of the consumers in the previous example.
 
 ## Implementation
 
-When we’re *not* doing OnDemand, things work like this:   When a timestep is created on the writer, the metadata for it gets sent to every reader (and queued there if it’s not immediately needed).  Then when the writer does Close(), it also sends a close message to every reader noting it’s new status.  The reader then knows that it’s at end-of-stream when 1) it has no more metadata, and 2) it has received a close message so it knows the writer won’t be producing more timesteps.  That’s safe because the metadata messages are guaranteed to arrive before the close message.
+**Issue 1** 
+
+For AlltoAll or RoundRobin:
+
+- When a timestep is created on the writer, the metadata for it gets sent to every reader (and queued there if it’s not immediately needed).  Then when the writer does Close(), it also sends a close message to every reader noting it’s new status.  The reader then knows that it’s at end-of-stream when 
+   1) it has no more metadata, and 
+   2) it has received a close message so it knows the writer won’t be producing more timesteps. That’s safe because the metadata messages are guaranteed to arrive before the close message.
  
-This is a bit messier with OnDemand.   What happens is that by default we send no metadata to anyone, but instead as soon as the reader enters BeginStep we send a TimestepRequest message to the writer.  Then we fall into the more standard BeginStep handling (specifically SstAdvanceStepMin() in sst/cp/cp_reader.c if you’re morbidly curious).  That is, we look to see if we have any metadata queued and if not, we wait for it.  OR we return EndOfStream if we have no more metadata and we have received a close message from the writer.  Unfortunately in the OnDemand case this is a race condition because the writer might send us more metadata (for example for the last step) in response to that OnDemand message.  If that metadata arrives before we look for it in SstAdvanceStepMin(), we’ll get all the steps and everything will be fine.  If it doesn’t, we’ll see that there’s no metadata queued and the writer has already send a close message, so we conclude EndOfStream.
+With OnDemand:
+- By default we send no metadata to anyone, but instead as soon as the reader enters BeginStep we send a TimestepRequest message to the writer.  
+- Then we fall into the more standard BeginStep handling (specifically `SstAdvanceStepMin()` in `sst/cp/cp_reader.c`).  That is, we look to see if we have any metadata queued and if not, we wait for it.  OR we return EndOfStream if we have no more metadata and we have received a close message from the writer.  
+- in the OnDemand case this is a race condition because the writer might send us more metadata (for example for the last step) in response to that OnDemand message.  If that metadata arrives before we look for it in `SstAdvanceStepMin()`, we’ll get all the steps and everything will be fine.  If it doesn’t, we’ll see that there’s no metadata queued and the writer has already send a close message, so we conclude EndOfStream.
  
-I need to mull over how best to handle this.  Maybe the best solution is that when we’re in OnDemand mode, we never send the close message until the last timestep which was produced has been delivered and released by whomever it was delivered to.  Just need to make sure that that also wakes up whoever has been waiting (because we might have multiple readers waiting in OnDemand for whatever metadata they are sent next). 
+**Issue 2** 
+
+We send metadata to the reader in two places in the code, 
+- when a new request message has just come in and we have metadata queued,
+- when new metadata has just come in from the writer and we have requests queued.  
+
+In one of those cases the line of code that updates the last timestep that had been sent on demand was missing.  That produced a different race condition.  * A timestep sent there might be sent just once because once it’s been consumed by the reader, we’ll get a release message and it will be removed from the queue, but since it’s not removed until we get that release message, we might send it again if we get another TimestepRequest message while it’s still in the queue.*

--- a/DataStreaming/ADIOS_ondemand/README.md
+++ b/DataStreaming/ADIOS_ondemand/README.md
@@ -41,3 +41,12 @@ p2: Get step 5
 SST,Read,1,100,1,3,286,8430
 ```
 Step 3 is not read by any of the consumers in the previous example.
+
+
+## Implementation
+
+When we’re *not* doing OnDemand, things work like this:   When a timestep is created on the writer, the metadata for it gets sent to every reader (and queued there if it’s not immediately needed).  Then when the writer does Close(), it also sends a close message to every reader noting it’s new status.  The reader then knows that it’s at end-of-stream when 1) it has no more metadata, and 2) it has received a close message so it knows the writer won’t be producing more timesteps.  That’s safe because the metadata messages are guaranteed to arrive before the close message.
+ 
+This is a bit messier with OnDemand.   What happens is that by default we send no metadata to anyone, but instead as soon as the reader enters BeginStep we send a TimestepRequest message to the writer.  Then we fall into the more standard BeginStep handling (specifically SstAdvanceStepMin() in sst/cp/cp_reader.c if you’re morbidly curious).  That is, we look to see if we have any metadata queued and if not, we wait for it.  OR we return EndOfStream if we have no more metadata and we have received a close message from the writer.  Unfortunately in the OnDemand case this is a race condition because the writer might send us more metadata (for example for the last step) in response to that OnDemand message.  If that metadata arrives before we look for it in SstAdvanceStepMin(), we’ll get all the steps and everything will be fine.  If it doesn’t, we’ll see that there’s no metadata queued and the writer has already send a close message, so we conclude EndOfStream.
+ 
+I need to mull over how best to handle this.  Maybe the best solution is that when we’re in OnDemand mode, we never send the close message until the last timestep which was produced has been delivered and released by whomever it was delivered to.  Just need to make sure that that also wakes up whoever has been waiting (because we might have multiple readers waiting in OnDemand for whatever metadata they are sent next). 


### PR DESCRIPTION
```
writer: Puts step 0

writer: Preparing to send timestep 0
writer: Send tilmestep 0 to rank 0

writer: Put step 1

writer: Preparing to send timestep 1
writer: Send tilmestep 1 to rank 1
writer: Put step 2 

writer: Preparing to send timestep 2

reader0: Get step 0

writer: Put step 3 

writer: Preparing to send timestep 3

reader0: Get step 2 

reader1: Get step 1

writer: Put step 4 

writer: Preparing to send timestep 4

reader1: Get step 2

writer: Put step 5

writer: Preparing to send timestep 5

writer: Send tilmestep 5 to rank 1

reader1: Get step 5
```

 
Also very rarely I get this:
```
0   libadios2_core.2.dylib              0x00000001102036b8 FFSMarshalInstallPreciousMetadata + 104

[mac122730:53255] [ 3] 0   libadios2_core.2.dylib              0x00000001101f5788 waitForNextMetadata + 216

[mac122730:53255] [ 4] 0   libadios2_core.2.dylib              0x00000001101f4663 SstAdvanceStepMin + 707

[mac122730:53255] [ 5] 0   libadios2_core.2.dylib              0x00000001101f3bad SstAdvanceStep + 381

[mac122730:53255] [ 6] 0   libadios2_core.2.dylib              0x000000011008ed53 _ZN6adios24core6engine9SstReader9BeginStepENS_8StepModeEf + 851

[mac122730:53255] [ 7] 0   libadios2_core.2.dylib              0x000000010f956e68 _ZN6adios24core6Engine9BeginStepEv + 56

[mac122730:53255] [ 8] 0   libadios2_cxx11.2.dylib             0x000000010ed63109 _ZN6adios26Engine9BeginStepEv + 89

[mac122730:53255] [ 9] 0   sstReader                           0x000000010ecdaada main + 842

[mac122730:53255] [10] 0   libdyld.dylib                       0x00007fff71574cc9 start + 1

[mac122730:53255] *** End of error message ***

Writer 0 (0x7fa7b541e540): Got an unexpected connection close event

[3]-  Segmentation fault: 11  ./build/bin/sstReader 100 2 p0

[2]-  Done                    ./build/bin/sstWriter 100 2 w
```